### PR TITLE
fix: ReadAll method read error

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -52,11 +52,14 @@ func (s *Socket) ReadAll(initialCap ...int) (datas []byte, err error) {
 		if n > 0 {
 			jsonBuf.Write(request[0:n])
 		}
-		if n < initial || err != nil {
-			break
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
 		}
 	}
-	return jsonBuf.Bytes(), err
+	return jsonBuf.Bytes(), nil
 }
 
 // Ping to detect whether the socket is closed.


### PR DESCRIPTION
code below will recur the bug.

server.go
```go
package main

import (
	"log"
	"net"
	"strings"
)

func handleConnection(conn net.Conn) {
       // write  2 * 1<<20 byte data to conn.
	conn.Write([]byte(strings.Repeat("hh", 1<<20)))
	conn.Close()
}

func main() {
	ln, err := net.Listen("tcp", ":8080")
	if err != nil {
		log.Fatal(err)
	}

	for {
		conn, err := ln.Accept()
		if err != nil {
			log.Println(err)
			continue
		}
		go handleConnection(conn)
	}
}
```
client.go
```go
package main

import (
	"fmt"
        "github.com/teambition/socket"
	"log"
)

func main() {
	address := ":8080"
	pool, err := socket.NewPool(1, 20, socket.NewFactory(address))
	if err != nil {
		log.Fatal(err)
	}
	s, err := pool.Get()
	if err != nil {
		log.Fatal(err)
	}

	d, err := s.ReadAll(1 << 20)
	if err != nil {
		fmt.Println(err)
	}

       // should print 2097152(1<<20)
	fmt.Println(len(d))
}
```
I think this should be a bug, it can not make sure that net.Conn.Read(buf) method always fullfill the buf when buf's length is longer enough.

